### PR TITLE
fix: :bug: #D3D3D3が#C0C0C0に置き換わるため#C0C0C0を使用

### DIFF
--- a/my-office-addin/src/constants/storage.ts
+++ b/my-office-addin/src/constants/storage.ts
@@ -1,6 +1,6 @@
 export const STORAGE_KEY = 'currentRuleName';
 export const CSV_FILE_STORAGE_ID = 'csvMappingFile';
 export const UNDO_STORAGE_KEY = 'undoRecords';
-export const HIGHLIGHT_COLOR = '#D3D3D3';
+export const HIGHLIGHT_COLOR = '#C0C0C0';
 export const DEFAULT_RULE_NAME = 'defaultRule';
 export const RULE_LIST_NAME = 'ruleList';


### PR DESCRIPTION
どうやら、Wordは内部的に色を置き換えることがあるらしい。